### PR TITLE
set HTTP_DATE for client

### DIFF
--- a/lib/ey_api_hmac/api_auth.rb
+++ b/lib/ey_api_hmac/api_auth.rb
@@ -61,6 +61,7 @@ module EY
           @app, @auth_id, @auth_key = app, auth_id, auth_key
         end
         def call(env)
+          env['HTTP_DATE'] ||= Time.now.httpdate
           ApiHMAC.sign!(env, @auth_id, @auth_key)
           tuple = @app.call(env)
           if tuple.first.to_i == 401


### PR DESCRIPTION
``` ruby
client = Rack::Client.new do
    use EY::ApiHMAC::ApiAuth::Client, auth_id_arg, auth_key_arg
    run someapp
end
```

doesn't work if the client.verb doesn't set the HTTP_DATE.
