### PR TITLE
Updated hashing to SHA256.

### DIFF
--- a/ey_api_hmac.rb
+++ b/ey_api_hmac.rb
@@ -1,0 +1,92 @@
+require 'ey_api_hmac/authed_connection'
+require 'ey_api_hmac/api_auth'
+require 'ey_api_hmac/sso'
+
+module EY
+  module ApiHMAC
+    require 'openssl'
+
+    def self.sign!(env, key_id, secret)
+      env["HTTP_AUTHORIZATION"] = auth_string(key_id, signature(env, secret))
+    end
+
+    def self.canonical_string(env, legacy = false)
+      parts = []
+      expect = Proc.new do |var|
+        unless env[var]
+          raise HmacAuthFail, "'#{var}' header missing and required in #{env.inspect}"
+        end
+        env[var]
+      end
+      parts << expect["REQUEST_METHOD"]
+      parts << env["CONTENT_TYPE"]
+      parts << generated_md5(env, legacy)
+      parts << expect["HTTP_DATE"]
+      if env["REQUEST_URI"]
+        parts << URI.parse(env["REQUEST_URI"]).path
+      else
+        parts << (env["SCRIPT_NAME"] + expect["PATH_INFO"])
+      end
+      parts.join("\n")
+    end
+
+    def self.auth_string(key_id, signature)
+      "AuthHMAC #{key_id}:#{signature}"
+    end
+
+    def self.signature(env, secret)
+      base64digest(canonical_string(env), secret)
+    end
+
+    def self.signature_legacy(env, secret)
+      base64digest(canonical_string(env, true), secret)
+    end
+
+    def self.base64digest(data,secret)
+      digest = OpenSSL::Digest::Digest.new('sha256')
+      [OpenSSL::HMAC.digest(digest, secret, data)].pack('m').strip
+    end
+
+    class HmacAuthFail < StandardError; end
+
+    def self.authenticate!(env, &lookup)
+      rx = Regexp.new("AuthHMAC ([^:]+):(.+)$")
+      if md = rx.match(env["HTTP_AUTHORIZATION"])
+        access_key_id = md[1]
+        hmac = md[2]
+        secret = lookup.call(access_key_id)
+        unless secret
+          raise HmacAuthFail, "couldn't find auth for #{access_key_id}"
+        end
+        unless hmac == signature(env, secret) || hmac == signature_legacy(env, secret)
+          raise HmacAuthFail, "signature mismatch. Calculated canonical_string: #{canonical_string(env).inspect}"
+        end
+      else
+        raise HmacAuthFail, "no authorization header"
+      end
+    end
+
+    def self.authenticated?(env, &lookup)
+      begin
+        authenticate!(env, &lookup)
+        true
+      rescue HmacAuthFail => e
+        false
+      end
+    end
+
+    private
+
+    def self.generated_md5(env, legacy = false)
+      env["rack.input"].rewind
+      request_body = env["rack.input"].read
+      env["rack.input"].rewind
+      if legacy
+        OpenSSL::Digest::SHA256.hexdigest(request_body)
+      else
+        request_body.empty? ? nil : OpenSSL::Digest::SHA256.hexdigest(request_body)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Updated the gem to sign with SHA256 instead of SHA1 and replaced MD5 with SHA256 as well.

Using SHA1 for signing api requests is a bad security practice, as well as using MD5. SHA1 is vulnerable to replay attacks where an attacker knows the body and signature for a valid API call because of the way the SHA1 algorithm works, the attacker can append null bytes to fill out the last iteration of the hashing algorithm, then append a malicious message. Because the attacker knows the hash value that will be used to sign the original+null_bytes+malicious_message, he can sign the new message without knowing the secret. To read more about length expansion attacks on SHA1, see https://blog.whitehatsec.com/hash-length-extension-attacks/.
